### PR TITLE
added allow-releaseinfo-change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
     DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get --allow-releaseinfo-change update
 RUN apt-get update -y && \
     apt-get upgrade -y
 


### PR DESCRIPTION
debian dockerfile appears to now fail when building due to an update

However this additional command fixes it

RUN apt-get --allow-releaseinfo-change update