### PR TITLE
added option to add scale to dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ cad_to_h5m(
 )
 ```
 
-Creating a EXODUS mesh files compatible with the DAGMC Unstructured  mesh format
-is also possible. Another entry must be added to the ```files_with_tags```
-argument. The following command will produce a ```unstructured_mesh_file.exo```
+Creating a tet mesh files compatible with the OpenMC / DAGMC Unstructured mesh
+format is also possible. Another key called ```tet_mesh``` to the ```files_with_tags``` dictionary will tirgger the meshing of that CAD file.
+The value of the key will be passed to the Cubit mesh command as an instruction.
+The following command will produce a ```unstructured_mesh_file.exo```
 file that can then be used in DAGMC compatable neutronics codes. There are examples
 [1](https://docs.openmc.org/en/latest/examples/unstructured-mesh-part-i.html)
 [2](https://docs.openmc.org/en/latest/examples/unstructured-mesh-part-ii.html) 
@@ -106,12 +107,69 @@ for the use of unstructured meshes in OpenMC.
 from cad_to_h5m import cad_to_h5m
 
 cad_to_h5m(
-    files_with_tags=[{'cad_filename':'part1.sat', 'material_tags':'m1', 'tet_mesh': 'size 0.5'}],
+    files_with_tags=[
+        {
+            'cad_filename':'part1.sat',
+            'material_tags':'m1',
+            'tet_mesh': 'size 0.5'
+        }
+    ],
     h5m_filename='dagmc.h5m',
     cubit_path='/opt/Coreform-Cubit-2021.5/bin/'
     exo_filename='unstructured_mesh_file.exo'
 )
 ```
+
+Use if ```exo``` files requires OpenMC to be compiled with LibMesh. OpenMC also
+accepts DAGMC tet meshes made with MOAB which is another option. The following
+example creates a ```cub``` file that contains a mesh. The MOAB tool 
+```mbconvert``` is then used to extract the tet mesh and save it as a ```h5m```
+file which cna be used in OpenMC as shown in the OpenMC [examples](https://docs.openmc.org/en/stable/examples/unstructured-mesh-part-i.html)
+
+```python
+from cad_to_h5m import cad_to_h5m
+
+cad_to_h5m(
+    files_with_tags=[
+        {
+            'cad_filename':'part1.sat',
+            'material_tags':'m1',
+            'tet_mesh': 'size 0.5'
+        }
+    ],
+    h5m_filename='dagmc.h5m',
+    cubit_path='/opt/Coreform-Cubit-2021.5/bin/'
+    cubit_filename='unstructured_mesh_file.cub'
+)
+```
+mbconvert is a terminal command that is part of MOAB.
+```bash
+mbconvert unstructured_mesh_file.cub unstructured_mesh_file.h5m
+```
+
+Scaling geometry is also possible. This is useful as particle transport codes
+often make use of cm as the default unit. CAD files typically appear in mm as
+the default limit. Some CAD packages ignore units while others make use of them.
+The h5m files are assumed to be in cm by particle transport codes so often it
+is nessecary to scale up or down the geometry. This can be done by adding
+another key called ```scale``` and a value to the ```files_with_tags```
+dictionary. This example multiplies the geometry by 10.
+
+```python
+from cad_to_h5m import cad_to_h5m
+
+cad_to_h5m(
+    files_with_tags=[
+        {
+            'cad_filename':'part1.sat',
+            'material_tags':'m1',
+            'scale': 10
+        }
+    ],
+    h5m_filename='dagmc.h5m',
+)
+```
+
 
 # Installation
 

--- a/cad_to_h5m/core.py
+++ b/cad_to_h5m/core.py
@@ -9,6 +9,7 @@ class FilesWithTags(TypedDict, total=False):
     filename: str
     material_tag: str
     tet_mesh: str
+    scale: float
 
 
 def cad_to_h5m(
@@ -35,7 +36,10 @@ def cad_to_h5m(
         "mat2", "cad_filename": "part2.stp"}]. There is also an option to create
         a tet mesh of entries by including a "tet_mesh" key in the dictionary.
         The value is passed to the Cubit mesh command. An example entry would be
-        "tet_mesh": "size 0.5"
+        "tet_mesh": "size 0.5". The scale key can also be included to scale up
+        or down the geometry so that it is in cm units as required by most
+        particle transport codes. And example entry would be "scale": 10 which
+        would make the geometry 10 times bigger.
     h5m_filename: the file name of the output h5m file which is suitable for
         use in DAGMC enabled particle transport codes.
     cubit_filename: the file name of the output cubit file. Should end with .cub
@@ -103,6 +107,9 @@ def cad_to_h5m(
     geometry_details, total_number_of_volumes = find_number_of_volumes_in_each_step_file(
         files_with_tags, cubit)
     print(geometry_details)
+
+    scale_geometry(cubit, geometry_details)
+
     tag_geometry_with_mats(geometry_details, cubit)
 
     if imprint and total_number_of_volumes > 1:
@@ -145,6 +152,12 @@ def create_tet_mesh(geometry_details, exo_filename, cubit):
                 cubit.cmd(f"volume {volume} " + entry["tet_mesh"])
                 cubit.cmd("mesh volume " + str(volume))
             print('meshed some volumes')
+
+
+def scale_geometry(cubit, geometry_details):
+    for entry in geometry_details:
+        if 'scale' in entry.keys():
+            cubit.cmd(f'volume {" ".join(entry["volumes"])}  scale  {entry["scale"]}')
 
 
 # def save_tet_details_to_json_file(

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -226,3 +226,27 @@ class TestApiUsage(unittest.TestCase):
                 cubit_filename="output_file_with.not_correct_suffix",
             )
         self.assertRaises(ValueError, incorrect_suffix)
+
+    def test_h5m_file_creation_with_scaling(self):
+        """Checks that a h5m file is created from stp files when make_watertight
+        is set to false"""
+
+        os.system("rm test_dagmc.h5m")
+
+        test_h5m_filename = "test_dagmc.h5m"
+
+        returned_filename = cad_to_h5m(
+            files_with_tags=[
+                {
+                    "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/blanket.stp",
+                    "material_tag": "mat1",
+                    "scale":0.1,
+                }
+            ],
+            h5m_filename=test_h5m_filename,
+            make_watertight=False,
+        )
+
+        assert Path(test_h5m_filename).is_file()
+        assert Path(returned_filename).is_file()
+        assert test_h5m_filename == returned_filename

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -140,6 +140,19 @@ class TestApiUsage(unittest.TestCase):
     def test_exo_file_creation_with_different_sizes(self):
         """Checks that a h5m file is created from stp files"""
 
+        os.system("rm umesh_2.exo")
+
+        cad_to_h5m(
+            files_with_tags=[
+                {
+                    "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
+                    "material_tag": "mat1",
+                    "tet_mesh": "size 2"}],
+            exo_filename="umesh_2.exo",
+        )
+
+        assert Path("umesh_2.exo").is_file()
+
         os.system("rm umesh_3.exo")
 
         cad_to_h5m(
@@ -153,21 +166,8 @@ class TestApiUsage(unittest.TestCase):
 
         assert Path("umesh_3.exo").is_file()
 
-        os.system("rm umesh_4.exo")
-
-        cad_to_h5m(
-            files_with_tags=[
-                {
-                    "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
-                    "material_tag": "mat1",
-                    "tet_mesh": "size 4"}],
-            exo_filename="umesh_4.exo",
-        )
-
-        assert Path("umesh_4.exo").is_file()
-
-        assert (Path("umesh_4.exo").stat().st_size >
-                Path("umesh_3.exo").stat().st_size)
+        assert (Path("umesh_3.exo").stat().st_size >
+                Path("umesh_2.exo").stat().st_size)
 
     def test_exo_file_creation_with_default_size(self):
         """Checks that a h5m file is created from stp files"""

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -19,6 +19,10 @@ class TestApiUsage(unittest.TestCase):
         tar.extractall("tests")
         tar.close()
 
+        url = "https://raw.githubusercontent.com/fusion-energy/neutronics_workflow/2f65bdeb802f2b1b25da683d13dcd2b29ffc9ed3/example_05_3D_unstructured_mesh_tally/stage_1_output/steel.stp"
+        urllib.request.urlretrieve(url, "tests/steel.stp")
+
+
     def test_h5m_file_creation(self):
         """Checks that a h5m file is created from stp files when make_watertight
         is set to false"""
@@ -145,9 +149,10 @@ class TestApiUsage(unittest.TestCase):
         cad_to_h5m(
             files_with_tags=[
                 {
-                    "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
+                    "cad_filename": "tests/steel.stp",
                     "material_tag": "mat1",
-                    "tet_mesh": "size 2"}],
+                    "tet_mesh": "size 2"
+                }],
             exo_filename="umesh_2.exo",
         )
 
@@ -158,9 +163,10 @@ class TestApiUsage(unittest.TestCase):
         cad_to_h5m(
             files_with_tags=[
                 {
-                    "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
+                    "cad_filename": "tests/steel.stp",
                     "material_tag": "mat1",
-                    "tet_mesh": "size 3"}],
+                    "tet_mesh": "size 3"
+                }],
             exo_filename="umesh_3.exo",
         )
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -153,20 +153,20 @@ class TestApiUsage(unittest.TestCase):
 
         assert Path("umesh_3.exo").is_file()
 
-        os.system("rm umesh_10.exo")
+        os.system("rm umesh_4.exo")
 
         cad_to_h5m(
             files_with_tags=[
                 {
                     "cad_filename": "tests/fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
                     "material_tag": "mat1",
-                    "tet_mesh": "size 10"}],
-            exo_filename="umesh_10.exo",
+                    "tet_mesh": "size 4"}],
+            exo_filename="umesh_4.exo",
         )
 
-        assert Path("umesh_10.exo").is_file()
+        assert Path("umesh_4.exo").is_file()
 
-        assert (Path("umesh_10.exo").stat().st_size >
+        assert (Path("umesh_4.exo").stat().st_size >
                 Path("umesh_3.exo").stat().st_size)
 
     def test_exo_file_creation_with_default_size(self):
@@ -244,7 +244,6 @@ class TestApiUsage(unittest.TestCase):
                 }
             ],
             h5m_filename=test_h5m_filename,
-            make_watertight=False,
         )
 
         assert Path(test_h5m_filename).is_file()


### PR DESCRIPTION
This PR attempts to add the option to scale geometry as discussed in #26 

A new key option has been introduced to the dictionary

```python
cad_to_h5m(
            files_with_tags=[
                {
                    "cad_filename": "blanket.stp",
                    "material_tag": "mat1",
                    "scale":0.1,
                }
            ],
            h5m_filename='dagmc.h5m',
        )
```