### PR TITLE
Adds verbose option to the args

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cad-to-h5m -i part1.stp -o dagmc.h5m -t mat:1 -c /opt/Coreform-Cubit-2021.5/bin/
 
 Multiple STP or SAT files can also be combined and converted into a DAGMC
 geometry. This example combines two STP files into a single geometry with
-seperate material tags for each STP file and saves the result as a h5m file.
+separate material tags for each STP file and saves the result as a h5m file.
 
 ```bash
 cad-to-h5m -i part1.stp part2.stp -o dagmc.h5m -t mat:1 mat:2 -c /opt/Coreform-Cubit-2021.5/bin/
@@ -107,10 +107,10 @@ cad_to_h5m(
 ```
 
 Creating a tet mesh files compatible with the OpenMC / DAGMC Unstructured mesh
-format is also possible. Another key called ```tet_mesh``` to the ```files_with_tags``` dictionary will tirgger the meshing of that CAD file.
+format is also possible. Another key called ```tet_mesh``` to the ```files_with_tags``` dictionary will trigger the meshing of that CAD file.
 The value of the key will be passed to the Cubit mesh command as an instruction.
 The following command will produce a ```unstructured_mesh_file.exo```
-file that can then be used in DAGMC compatable neutronics codes. There are examples
+file that can then be used in DAGMC compatible neutronics codes. There are examples
 [1](https://docs.openmc.org/en/latest/examples/unstructured-mesh-part-i.html)
 [2](https://docs.openmc.org/en/latest/examples/unstructured-mesh-part-ii.html) 
 for the use of unstructured meshes in OpenMC.
@@ -156,8 +156,8 @@ cad_to_h5m(
 ```
 The ```cub``` file produced contains a tet mesh as well as the faceted geometry.
 The tet mesh can be extracted and converted to another ```h5m``` file for use in
-openmc. MOAB is needed to convert the file and includes the command line tool
-```mbconvert```, MOAB can be installed into a conda environment with:
+OpenMC. MOAB is needed to convert the file and includes the command line tool
+```mbconvert```, MOAB can be installed into a Conda environment with:
 
 ```
 conda install -c conda-forge moab
@@ -169,12 +169,11 @@ Then ```mbconvert``` can be used to extract and convert the tet mesh from the
 mbconvert unstructured_mesh_file.cub unstructured_mesh_file.h5m
 ```
 
-
 Scaling geometry is also possible. This is useful as particle transport codes
 often make use of cm as the default unit. CAD files typically appear in mm as
 the default limit. Some CAD packages ignore units while others make use of them.
 The h5m files are assumed to be in cm by particle transport codes so often it
-is nessecary to scale up or down the geometry. This can be done by adding
+is necessary to scale up or down the geometry. This can be done by adding
 another key called ```scale``` and a value to the ```files_with_tags```
 dictionary. This example multiplies the geometry by 10.
 
@@ -193,10 +192,7 @@ cad_to_h5m(
 )
 ```
 
-Assigning a material to the implicit complement is also possible. This can be useful 
-on large complex geometries where boolean operations can result in robustness issues. 
-This is implemented by assigning the desired material tag of the implicit complement to the 
-optional ```implicit_complement_material_tag``` argument. Defaults to vacuum.
+Assigning a material to the implicit complement is also possible. This can be useful on large complex geometries where boolean operations can result in robustness issues. This is implemented by assigning the desired material tag of the implicit complement to the optional ```implicit_complement_material_tag``` argument. Defaults to vacuum.
 
 ```python
 from cad_to_h5m import cad_to_h5m

--- a/cad_to_h5m/core.py
+++ b/cad_to_h5m/core.py
@@ -24,7 +24,8 @@ def cad_to_h5m(
     geometry_details_filename: Optional[str] = None,
     surface_reflectivity_name: str = "reflective",
     exo_filename: Optional[str] = None,
-    implicit_complement_material_tag: Optional[str] = None
+    implicit_complement_material_tag: Optional[str] = None,
+    verbose: bool = True
 ):
     """Converts a CAD files in STP or SAT format into a h5m file for use in
     DAGMC simulations. The h5m file contains material tags associated with the
@@ -106,10 +107,14 @@ def cad_to_h5m(
         raise ImportError(msg)
 
     cubit.init([])
+    if not verbose:
+        cubit.cmd('set echo off')
+        cubit.cmd('set info off')
+        cubit.cmd('set journal off')
+        cubit.cmd('set warning off')
 
     geometry_details, total_number_of_volumes = find_number_of_volumes_in_each_step_file(
-        files_with_tags, cubit)
-    print(geometry_details)
+        files_with_tags, cubit, verbose)
 
     scale_geometry(geometry_details, cubit)
 
@@ -124,7 +129,7 @@ def cad_to_h5m(
 
     # TODO method requires further testing
     find_reflecting_surfaces_of_reflecting_wedge(
-        geometry_details, surface_reflectivity_name, cubit
+        geometry_details, surface_reflectivity_name, cubit, verbose
     )
 
     save_output_files(
@@ -136,6 +141,7 @@ def cad_to_h5m(
         faceting_tolerance,
         exo_filename,
         cubit,
+        verbose,
     )
     return h5m_filename
 
@@ -186,6 +192,7 @@ def save_output_files(
     faceting_tolerance: float,
     exo_filename: str,
     cubit,
+    verbose: bool
 ):
     """This saves the output files"""
     cubit.cmd("set attribute on")
@@ -195,8 +202,8 @@ def save_output_files(
             json.dump(geometry_details, outfile, indent=4)
 
     Path(h5m_filename).parents[0].mkdir(parents=True, exist_ok=True)
-
-    print("using faceting_tolerance of ", faceting_tolerance)
+    if verbose:
+        print("using faceting_tolerance of ", faceting_tolerance)
     if make_watertight:
         cubit.cmd(
             'export dagmc "'
@@ -241,7 +248,7 @@ def merge_geometry(merge_tolerance: float, cubit):
     cubit.cmd("merge vol all group_results")
 
 
-def find_all_surfaces_of_reflecting_wedge(new_vols, cubit):
+def find_all_surfaces_of_reflecting_wedge(new_vols, cubit, verbose: bool):
     surfaces_in_volume = cubit.parse_cubit_list(
         "surface", " in volume " + " ".join(new_vols)
     )
@@ -256,33 +263,38 @@ def find_all_surfaces_of_reflecting_wedge(new_vols, cubit):
             surface_info_dict[surface_id] = {"reflector": True}
         else:
             surface_info_dict[surface_id] = {"reflector": False}
-    print("surface_info_dict", surface_info_dict)
+    if verbose:
+        print("surface_info_dict", surface_info_dict)
     return surface_info_dict
 
 
 def find_reflecting_surfaces_of_reflecting_wedge(
-    geometry_details, surface_reflectivity_name, cubit
+    geometry_details, surface_reflectivity_name, cubit, verbose
 ):
-    print("running find_reflecting_surfaces_of_reflecting_wedge")
+    if verbose:
+        print("running find_reflecting_surfaces_of_reflecting_wedge")
     wedge_volume = None
     for entry in geometry_details:
-        print(entry)
-        print(entry.keys())
+        if verbose:
+            print(entry)
+            print(entry.keys())
         if "surface_reflectivity" in entry.keys():
-            print("found surface_reflectivity")
             surface_info_dict = entry["surface_reflectivity"]
             wedge_volume = " ".join(entry["volumes"])
-            print("wedge_volume", wedge_volume)
             surfaces_in_wedge_volume = cubit.parse_cubit_list(
                 "surface", " in volume " + str(wedge_volume)
             )
-            print("surfaces_in_wedge_volume", surfaces_in_wedge_volume)
+            if verbose:
+                print("found surface_reflectivity")
+                print("wedge_volume", wedge_volume)
+                print("surfaces_in_wedge_volume", surfaces_in_wedge_volume)
             for surface_id in surface_info_dict.keys():
                 if surface_info_dict[surface_id]["reflector"]:
-                    print(
-                        surface_id,
-                        "surface originally reflecting but does it still exist",
-                    )
+                    if verbose:
+                        print(
+                            surface_id,
+                            "surface originally reflecting but does it still exist",
+                        )
                     if surface_id not in surfaces_in_wedge_volume:
                         del surface_info_dict[surface_id]
             for surface_id in surfaces_in_wedge_volume:
@@ -329,10 +341,11 @@ def tag_geometry_with_mats(
             raise ValueError(msg)
 
 
-def find_number_of_volumes_in_each_step_file(files_with_tags, cubit):
+def find_number_of_volumes_in_each_step_file(files_with_tags, cubit, verbose):
     """ """
     for entry in files_with_tags:
-        print(f'loading {entry["cad_filename"]}')
+        if verbose:
+            print(f'loading {entry["cad_filename"]}')
         current_vols = cubit.parse_cubit_list("volume", "all")
         if entry["cad_filename"].endswith(
                 ".stp") or entry["cad_filename"].endswith(".step"):
@@ -377,13 +390,15 @@ def find_number_of_volumes_in_each_step_file(files_with_tags, cubit):
         if "surface_reflectivity" in entry.keys():
             entry["surface_reflectivity"] = find_all_surfaces_of_reflecting_wedge(
                 new_vols_after_unite, cubit)
-            print(
-                "entry['surface_reflectivity']",
-                entry["surface_reflectivity"])
+            if verbose:
+                print(
+                    "entry['surface_reflectivity']",
+                    entry["surface_reflectivity"])
     cubit.cmd("separate body all")
 
     # checks the cad is clean and catches some errors with the geometry early
     cubit.cmd("validate vol all")
-    cubit.cmd("autoheal analyze vol all")
+    # commented out as cmd not known see issue #3
+    # cubit.cmd("autoheal analyze vol all")
 
     return files_with_tags, sum(all_vols)

--- a/examples/create_h5m_from_download_stp_files.py
+++ b/examples/create_h5m_from_download_stp_files.py
@@ -11,40 +11,54 @@ tar = tarfile.open("v0.0.1.tar.gz", "r:gz")
 tar.extractall()
 tar.close()
 
-cad_to_h5m(h5m_filename='dagmc.h5m',
-           cubit_path="/opt/Coreform-Cubit-2021.5/bin/",
-           files_with_tags=[{"material_tag": "pf_coil_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
-                             },
-                            {"material_tag": "pf_coil_case_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coil_cases.stp",
-                             },
-                            {"material_tag": "center_column_shield_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/center_column_shield.stp",
-                             },
-                            {"material_tag": "firstwall_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_firstwall.stp",
-                             },
-                            {"material_tag": "blanket_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/blanket.stp",
-                             },
-                            {"material_tag": "divertor_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/divertor.stp",
-                             },
-                            {"material_tag": "supports_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/supports.stp",
-                             },
-                            {"material_tag": "blanket_rear_wall_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_rear_blanket_wall.stp",
-                             },
-                            {"material_tag": "inboard_tf_coils_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/inboard_tf_coils.stp",
-                             },
-                            {"material_tag": "outer_tf_coil_mat",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_tf_coil.stp",
-                             },
-                            {"material_tag": "graveyard",
-                             "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/graveyard.stp",
-                             },
-                            ],
-           )
+cad_to_h5m(
+    h5m_filename="dagmc.h5m",
+    verbose=False,
+    cubit_path="/opt/Coreform-Cubit-2021.5/bin/",
+    files_with_tags=[
+        {
+            "material_tag": "pf_coil_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coils.stp",
+        },
+        {
+            "material_tag": "pf_coil_case_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/pf_coil_cases.stp",
+        },
+        {
+            "material_tag": "center_column_shield_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/center_column_shield.stp",
+        },
+        {
+            "material_tag": "firstwall_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_firstwall.stp",
+        },
+        {
+            "material_tag": "blanket_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/blanket.stp",
+        },
+        {
+            "material_tag": "divertor_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/divertor.stp",
+        },
+        {
+            "material_tag": "supports_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/supports.stp",
+        },
+        {
+            "material_tag": "blanket_rear_wall_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_rear_blanket_wall.stp",
+        },
+        {
+            "material_tag": "inboard_tf_coils_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/inboard_tf_coils.stp",
+        },
+        {
+            "material_tag": "outer_tf_coil_mat",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/outboard_tf_coil.stp",
+        },
+        {
+            "material_tag": "graveyard",
+            "cad_filename": "fusion_example_for_openmc_using_paramak-0.0.1/stp_files/graveyard.stp",
+        },
+    ],
+)

--- a/examples/create_h5m_from_paramak_reactor.py
+++ b/examples/create_h5m_from_paramak_reactor.py
@@ -36,5 +36,5 @@ files_with_tags = my_reactor.neutronics_description()
 cad_to_h5m(
     h5m_filename=' "dagmc.h5m',
     cubit_path="/opt/Coreform-Cubit-2021.5/bin/",
-    files_with_tags=files_with_tags
+    files_with_tags=files_with_tags,
 )

--- a/examples/create_h5m_from_paramak_shape.py
+++ b/examples/create_h5m_from_paramak_shape.py
@@ -16,5 +16,5 @@ files_with_tags = my_shape.neutronics_description()
 cad_to_h5m(
     h5m_filename=' "dagmc.h5m',
     cubit_path="/opt/Coreform-Cubit-2021.5/bin/",
-    files_with_tags=files_with_tags
+    files_with_tags=files_with_tags,
 )


### PR DESCRIPTION
As requested there is now a ```verbose``` argument that can be passed to the ```cad_to_h5m``` function to avoid some of the printing to screen and journal file production.