### PR TITLE
added reset

### DIFF
--- a/cad_to_h5m/core.py
+++ b/cad_to_h5m/core.py
@@ -143,6 +143,10 @@ def cad_to_h5m(
         cubit,
         verbose,
     )
+    
+    #resets cubit workspace
+    cubit.cmd('reset')
+    
     return h5m_filename
 
 


### PR DESCRIPTION
Added reset command to the cad_to_h5m() function. This will clear the cubit workspace after h5m files are exported which prevents overlapping geometries if cad_to_h5m is called more than once in the same session. 